### PR TITLE
feat: Ability to map a src label's single output file to a file in the output archive.

### DIFF
--- a/private/packager.go
+++ b/private/packager.go
@@ -71,28 +71,49 @@ func writeTarEntries(parsedSpec *BinarySpec, tw *tar.Writer) error {
 		entries = append(entries, entry)
 	}
 
-	var allFiles []*File
-	allFiles = append(allFiles, parsedSpec.BinaryRunfiles.Files...)
-	if parsedSpec.RepoMappingManifest != nil {
-		allFiles = append(allFiles, parsedSpec.RepoMappingManifest)
+	type fileToProcess struct {
+		file         *File
+		explicitName string
 	}
+
+	var allFiles []*fileToProcess
+	allFiles = append(allFiles, mapSlice(parsedSpec.BinaryRunfiles.Files, func(f *File) *fileToProcess {
+		return &fileToProcess{f, ""}
+	})...)
+
+	if parsedSpec.RepoMappingManifest != nil {
+		allFiles = append(allFiles, &fileToProcess{
+			file: parsedSpec.RepoMappingManifest,
+		})
+	}
+	allFiles = append(allFiles, mapSlice(parsedSpec.ExtraArchiveEntries, func(entry *ExtraArchiveEntry) *fileToProcess {
+		return &fileToProcess{
+			file:         entry.File,
+			explicitName: entry.ArchivePath,
+		}
+	})...)
 
 	eg := errgroup.Group{}
 	for _, runfile := range allFiles {
 		runfile := runfile
 		eg.Go(func() error {
-			contents, err := os.ReadFile(runfile.Path)
+			contents, err := os.ReadFile(runfile.file.Path)
 			if err != nil {
-				return fmt.Errorf("error reading %q (short_path = %q): %w", runfile.Path, runfile.ShortPath, err)
+				return fmt.Errorf("error reading %q (short_path = %q): %w", runfile.file.Path, runfile.file.ShortPath, err)
 			}
-			fileInfo, err := os.Stat(runfile.Path)
+			fileInfo, err := os.Stat(runfile.file.Path)
 			if err != nil {
-				return fmt.Errorf("error calling os.Stat on %q (short_path = %q): %w", runfile.Path, runfile.ShortPath, err)
+				return fmt.Errorf("error calling os.Stat on %q (short_path = %q): %w", runfile.file.Path, runfile.file.ShortPath, err)
+			}
+
+			name := runfile.explicitName
+			if name == "" {
+				name = nameInOutputArchive(runfile.file, parsedSpec.WorkspaceName, parsedSpec.BinaryTargetExecutableFile, parsedSpec.RepoMappingManifest, parsedSpec.ExecutableNameInArchive)
 			}
 
 			push(tarEntry{
 				header: &tar.Header{
-					Name: nameInOutputArchive(runfile, parsedSpec.WorkspaceName, parsedSpec.BinaryTargetExecutableFile, parsedSpec.RepoMappingManifest, parsedSpec.ExecutableNameInArchive),
+					Name: name,
 					Mode: int64(fileInfo.Mode().Perm()),
 					Size: int64(len(contents)),
 				},
@@ -181,6 +202,18 @@ type BinarySpec struct {
 	//
 	// [proposal]: https://github.com/bazelbuild/proposals/blob/main/designs/2022-07-21-locating-runfiles-with-bzlmod.md
 	RepoMappingManifest *File `json:"repo_mapping_manifest"`
+
+	// A list of extra files to be added to the output archive.
+	ExtraArchiveEntries []*ExtraArchiveEntry `json:"extra_archive_entries"`
+}
+
+// ExtraArchiveEntry specifies an extra entry in the output tar and its
+// corresponding [File].
+type ExtraArchiveEntry struct {
+	// The path of the file within the output archive.
+	ArchivePath string `json:"archive_path"`
+	// The input [File].
+	File *File `json:"file"`
 }
 
 // Runfiles contains information about a bazel runfiles object.
@@ -203,3 +236,12 @@ type File struct {
 
 // LabelString is a superficial type for https://bazel.build/rules/lib/builtins/Label.html.
 type LabelString string
+
+// mapSlice applies a function to each element of a slice and returns a new slice.
+func mapSlice[T, U any](slice []T, fn func(T) U) []U {
+	result := []U{}
+	for _, v := range slice {
+		result = append(result, fn(v))
+	}
+	return result
+}

--- a/private/pkg_with_runfiles.bzl
+++ b/private/pkg_with_runfiles.bzl
@@ -44,6 +44,26 @@ def _generate_input_spec(ctx):
 
     #fail("repo_mapping_manifest = {}".format(repo_mapping_manifest))
 
+    src_name_to_file = {}
+    for target, name in ctx.attr.named_srcs.items():
+        files = target[DefaultInfo].files.to_list()
+        if len(files) != 1:
+            fail("named label {}: {} must correspond to exactly 1 file, got {}".format(
+                target.label,
+                name,
+                len(files)
+            ))
+        src_name_to_file[name] = files[0]
+        inputs_to_packager.append(files[0])
+
+    def extra_archive_entry(archive_path, src_name):
+        if src_name not in src_name_to_file:
+            fail("bad entry in archive_path_to_named_src dict: name {} not found in named_srcs list; add a \"//foo/bar\": {} ".format(src_name, src_name))
+        return {
+            "archive_path": archive_path,
+            "file": _file_to_dict(src_name_to_file[src_name])
+        }
+
     return struct(
         inputs_to_packager = inputs_to_packager,
         spec_json = json.encode_indent(
@@ -60,7 +80,12 @@ def _generate_input_spec(ctx):
                     for f in target_info.files.to_list()
                 ],
                 "binary_runfiles": _runfiles_to_dict(target_runfiles),
-                "repo_mapping_manifest": _file_to_dict(repo_mapping_manifest) if repo_mapping_manifest else None
+                "repo_mapping_manifest": _file_to_dict(repo_mapping_manifest) if repo_mapping_manifest else None,
+                "extra_archive_entries": [
+                    extra_archive_entry(archive_path, src_name)
+                    for archive_path, src_name
+                    in ctx.attr.archive_path_to_named_src.items()
+                ],
             },
             indent = "  ",
         ),
@@ -149,6 +174,16 @@ pkg_with_runfiles = rule(
             doc = ("Extra dependencies that should be included as if they " +
                    "were included as data dependencies of the executable."),
             allow_files = True,
+        ),
+        "named_srcs": attr.label_keyed_string_dict(
+            doc = ("Variable names for labels that will be remapped to " +
+                "paths within the archive according to " +
+                "named_labels_archive_paths."),
+            allow_files = True,
+        ),
+        "archive_path_to_named_src": attr.string_dict(
+            doc = ("A dictionary from a path within the output archive " + 
+            "to one of the values in the named_srcs dict."),
         ),
         "_packager": attr.label(
             default = Label("//private:packager"),

--- a/tests/java-example/repo1/MODULE.bazel
+++ b/tests/java-example/repo1/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "repo1",
+    version = "0.1",
+)
+
+bazel_dep(name = "rules_java", version = "7.2.0")
+bazel_dep(name = "pkg_with_runfiles", version = "0.1")
+local_path_override(
+    module_name = "pkg_with_runfiles",
+    path = "../../..",
+)

--- a/tests/java-example/repo1/MODULE.bazel.lock
+++ b/tests/java-example/repo1/MODULE.bazel.lock
@@ -1,0 +1,132 @@
+{
+  "lockFileVersion": 11,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/source.json": "7e3a9adf473e9af076ae485ed649d5641ad50ec5c11718103f34de03170d94ad",
+    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
+    "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/source.json": "082ed5f9837901fada8c68c2f3ddc958bb22b6d654f71dd73f3df30d45d4b749",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.39.1/MODULE.bazel": "1fa3fefad240e535066fd0e6950dfccd627d36dc699ee0034645e51dbde3980f",
+    "https://bcr.bazel.build/modules/gazelle/0.39.1/source.json": "f2facfa8c8c9a4d2ebf613754023054c2eb793b88675082216c6be0419eb20a1",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
+    "https://bcr.bazel.build/modules/rules_go/0.50.1/source.json": "205765fd30216c70321f84c9a967267684bdc74350af3f3c46c857d9f80a4fa2",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
+    "https://bcr.bazel.build/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/source.json": "de77e10ff0ab16acbf54e6b46eecd37a99c5b290468ea1aee6e95eb1affdaed7",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
+    "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/source.json": "a96f95e02123320aa015b956f29c00cb818fa891ef823d55148e1a362caacf29",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/source.json": "f1ef7d3f9e0e26d4b23d1c39b5f5de71f584dd7d1b4ef83d9bbba6ec7a6a6459",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
+        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {}
+          },
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "usagesDigest": "V1R2Y2oMxKNfx2WCWpSCaUV1WefW1o8HZGm3v1vHgY4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "bzlFile": "@@platforms//host:extension.bzl",
+            "ruleClassName": "host_platform_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    }
+  }
+}

--- a/tests/java-example/repo1/com/example/BUILD.bazel
+++ b/tests/java-example/repo1/com/example/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@pkg_with_runfiles//:defs.bzl", "pkg_with_runfiles")
+
+pkg_with_runfiles(
+    name = "pkg",
+    binary = ":program",
+    binary_path_in_archive = "foo/program",
+    named_srcs = {
+        ":program_deploy.jar": "deploy_jar",
+    },
+    archive_path_to_named_src = {
+        "foo/program_deploy.jar": "deploy_jar",
+    },
+    extra_data = [],
+)
+
+java_binary(
+    name = "program",
+    srcs = ["ExampleProgram.java"],
+    main_class = "com.example.ExampleProgram",
+)

--- a/tests/java-example/repo1/com/example/ExampleProgram.java
+++ b/tests/java-example/repo1/com/example/ExampleProgram.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class ExampleProgram {
+
+    public static void main(String[] args) {
+        System.out.println("Hello, World!"); 
+    }
+}

--- a/tests/java-example/test.sh
+++ b/tests/java-example/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# For why, see
+# https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425
+set -euxo pipefail
+
+cd repo1
+bazel build //com/example:pkg
+
+# Create a temporary directory
+temp_dir=$(mktemp -d)
+
+# Ensure cleanup of the temporary directory on exit
+trap 'rm -rf "$temp_dir"' EXIT
+
+# Copy the tar file to the temporary directory
+cp "bazel-bin/com/example/pkg.tar" "$temp_dir/"
+
+# Extract the tar file
+tar -xf "$temp_dir/pkg.tar" -C "$temp_dir"
+
+# Run the program
+"$temp_dir/foo/program" --singlejar


### PR DESCRIPTION
For a java_binary, this is useful for packaging up a _deploy.jar target alongside the main binary.

Example usage:

```starlark
load("@rules_java//java:defs.bzl", "java_binary")
load("@pkg_with_runfiles//:defs.bzl", "pkg_with_runfiles")

pkg_with_runfiles(
    name = "pkg",
    binary = ":program",
    binary_path_in_archive = "foo/program",
    named_srcs = {
        ":program_deploy.jar": "deploy_jar",
    },
    archive_path_to_named_src = {
        "foo/program_deploy.jar": "deploy_jar",
    },
    extra_data = [],
)

java_binary(
    name = "program",
    srcs = ["ExampleProgram.java"],
    main_class = "com.example.ExampleProgram",
)
```